### PR TITLE
test: added a test for violation WPS357. A raw string must contain th…

### DIFF
--- a/tests/fixtures/noqa/noqa.py
+++ b/tests/fixtures/noqa/noqa.py
@@ -692,3 +692,5 @@ extra_new_line = [  # noqa: WPS355
     'wrong',
 ]
 *numbers, = [4, 7]  # noqa: WPS356
+
+unnecessary_raw_string = r'this string does not contain any backlashes.' # noqa: WPS357

--- a/tests/test_checker/test_noqa.py
+++ b/tests/test_checker/test_noqa.py
@@ -162,6 +162,7 @@ SHOULD_BE_RAISED = types.MappingProxyType({
     'WPS354': 1,
     'WPS355': 1,
     'WPS356': 1,
+    'WPS357': 1,
 
     'WPS400': 0,  # defined in ignored violations.
     'WPS401': 0,  # logically unacceptable.


### PR DESCRIPTION
…e '\' character. If there is no '\' in the string a raw string should not be used.

Closes issue #8
Relates to issue#1081 on the original repository
